### PR TITLE
prevent path from being cleared when cancelling browse folder

### DIFF
--- a/pyside2kit/ps2kit.py
+++ b/pyside2kit/ps2kit.py
@@ -296,7 +296,8 @@ class QBrowseFolder(QtWidgets.QWidget):
         else:
             root_folder = self.root_folder
         browsed_folder = QtWidgets.QFileDialog.getExistingDirectory(self, self.title, root_folder)
-        self._folder_line_edit.setText(browsed_folder)
+        if browsed_folder:
+            self._folder_line_edit.setText(browsed_folder)
 
     def get_folder(self):
         """


### PR DESCRIPTION
currently the path will dissapear when user clicks cancel,
which is not good for the user experience
now we check if a folder was selected before changing the filepath